### PR TITLE
fix(eks): removed unsupported option from kubernetes provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -327,7 +327,6 @@ provider "kubernetes" {
   host                   = aws_eks_cluster.cp.endpoint
   token                  = data.aws_eks_cluster_auth.cp.token
   cluster_ca_certificate = base64decode(aws_eks_cluster.cp.certificate_authority.0.data)
-  load_config_file       = false
 }
 
 resource "time_sleep" "wait" {


### PR DESCRIPTION
to fix the error:

```
Error: Unsupported argument

  on .terraform/modules/spinnaker.eks/main.tf line 330, in provider "kubernetes":
 330:   load_config_file       = false

An argument named "load_config_file" is not expected here.
```