### PR TITLE
fix: irsa expected length of name to be in the range (1 - 64)

### DIFF
--- a/modules/iam-role-for-serviceaccount/labels.tf
+++ b/modules/iam-role-for-serviceaccount/labels.tf
@@ -9,7 +9,7 @@ resource "random_string" "irsa-suffix" {
 
 locals {
   suffix = var.enabled ? random_string.irsa-suffix.0.result : ""
-  name   = var.name == null ? join("-", ["irsa", local.suffix]) : var.name
+  name   = var.name == null ? substr(join("-", ["irsa", local.suffix]), 0, 64) : substr(var.name, 0, 64)
   default-tags = merge(
     { "terraform.io" = "managed" },
     { "Name" = local.name },


### PR DESCRIPTION
when trying your repository on a cluster with a big name....

I have the following error:
```
Error: expected length of name to be in the range (1 - 64), got ......
```

the PR tries to fix the problem as easy I came up with.
