### PR TITLE
fix: autoscaler now requires 500MiB instead of 300MiB

### DIFF
--- a/modules/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
+++ b/modules/cluster-autoscaler/charts/cluster-autoscaler/values.yaml
@@ -72,10 +72,10 @@ ingress:
 resources:
   limits:
     cpu: 100m
-    memory: 300Mi
+    memory: 500Mi
   requests:
     cpu: 100m
-    memory: 300Mi
+    memory: 500Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
* Fixes: #88
* Original issue: https://github.com/kubernetes/autoscaler/issues/4220