### PR TITLE
iam-role-for-serviceaccount: add path variable for role

### DIFF
--- a/modules/iam-role-for-serviceaccount/main.tf
+++ b/modules/iam-role-for-serviceaccount/main.tf
@@ -6,7 +6,7 @@ locals {
 resource "aws_iam_role" "irsa" {
   count = var.enabled ? 1 : 0
   name  = format("%s", local.name)
-  path  = "/"
+  path  = var.path
   tags  = merge(local.default-tags, var.tags)
   assume_role_policy = jsonencode({
     Statement = [{

--- a/modules/iam-role-for-serviceaccount/variables.tf
+++ b/modules/iam-role-for-serviceaccount/variables.tf
@@ -38,6 +38,12 @@ variable "name" {
   default     = null
 }
 
+variable "path" {
+  description = "The path for role"
+  type        = string
+  default     = "/"
+}
+
 ### tags
 variable "tags" {
   description = "The key-value maps for tagging"


### PR DESCRIPTION
For `iam-role-for-serviceaccount` module: add path variable for role

More information can be found here: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-friendly-names