### PR TITLE
feat: add a variable to disable container insigts metrics and logs

### DIFF
--- a/modules/container-insights/main.tf
+++ b/modules/container-insights/main.tf
@@ -2,7 +2,7 @@
 
 module "irsa-metrics" {
   source         = "../iam-role-for-serviceaccount"
-  count          = var.enabled ? 1 : 0
+  count          = (var.enabled && var.enable-metrics) ? 1 : 0
   name           = join("-", compact(["irsa", var.cluster_name, "amazon-cloudwatch", local.suffix]))
   namespace      = "amazon-cloudwatch"
   serviceaccount = "amazon-cloudwatch"
@@ -13,7 +13,7 @@ module "irsa-metrics" {
 }
 
 resource "helm_release" "metrics" {
-  count            = var.enabled ? 1 : 0
+  count            = (var.enabled && var.enable-metrics) ? 1 : 0
   name             = "aws-cloudwatch-metrics"
   chart            = "aws-cloudwatch-metrics"
   version          = lookup(var.helm, "version", null)
@@ -37,7 +37,7 @@ resource "helm_release" "metrics" {
 
 module "irsa-logs" {
   source         = "../iam-role-for-serviceaccount"
-  count          = var.enabled ? 1 : 0
+  count          = (var.enabled && var.enable-logs) ? 1 : 0
   name           = join("-", compact(["irsa", var.cluster_name, "aws-for-fluent-bit", local.suffix]))
   namespace      = "kube-system"
   serviceaccount = "aws-for-fluent-bit"
@@ -48,7 +48,7 @@ module "irsa-logs" {
 }
 
 resource "helm_release" "logs" {
-  count           = var.enabled ? 1 : 0
+  count           = (var.enabled && var.enable-logs) ? 1 : 0
   name            = "aws-for-fluent-bit"
   chart           = "aws-for-fluent-bit"
   version         = lookup(var.helm, "version", null)

--- a/modules/container-insights/variables.tf
+++ b/modules/container-insights/variables.tf
@@ -1,5 +1,17 @@
 variable "enabled" {
-  description = "A conditional indicator to enable cluster-autoscale"
+  description = "A conditional indicator to enable container-insights"
+  type        = bool
+  default     = true
+}
+
+variable "enable-logs" {
+  description = "A conditional indicator to enable logs"
+  type        = bool
+  default     = true
+}
+
+variable "enable-metrics" {
+  description = "A conditional indicator to enable metrics"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
Motivation:

I have been using your terraform project sucessfully in production environments since several month.

but container-insigths metrics is expensive so our clients are worried about the billings.

I wanted to discuss how to disable metrics with this PR.

PS: I didn't test this PR I will update this PR when I deploy it in my internal cluster.

Thanks.

edit:
PS2: I already tested this PR disabling cloudwatch insights metrics and it worked. (I have logs but not metrics)