### PR TITLE
Add init script

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,6 +129,12 @@ data "cloudinit_config" "ng" {
   base64_encode = true
   gzip          = false
 
+  # Optional script which is executed prior to the remaining cloudinit_config
+  part {
+    content_type = "text/x-shellscript"
+    content      = lookup(each.value, "init_script", "")
+  }
+
   part {
     content_type = "text/x-shellscript"
     content      = <<-EOT
@@ -293,6 +299,12 @@ data "cloudinit_config" "mng" {
   for_each      = { for ng in var.managed_node_groups : ng.name => ng }
   base64_encode = true
   gzip          = false
+
+  # Optional script which is executed prior to the remaining cloudinit_config
+  part {
+    content_type = "text/x-shellscript"
+    content      = lookup(each.value, "init_script", "")
+  }
 
   # Main cloud-config configuration file.
   part {


### PR DESCRIPTION
This pull request adds an optional init script which is executed at the beginning of the cloudinit configuration. I need this change to install wireguard into Amazon Linux 2 which does not support the required kernel modules.

Please ignore the diff relating to the templatefile from the other PR. If you want to I can fix this into an independent PR.