### PR TITLE
Add labels and taints for managed node groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -344,6 +344,16 @@ resource "aws_eks_node_group" "ng" {
   instance_types  = [lookup(each.value, "instance_type", local.default_eks_config.instance_type)]
   version         = aws_eks_cluster.cp.version
   tags            = merge(local.default-tags, var.tags)
+  labels          = lookup(each.value, "labels", {})
+
+  dynamic "taint" {
+    for_each = lookup(each.value, "taints", {})
+    content {
+      key    = taint.value.key
+      value  = lookup(taint.value, "value")
+      effect = taint.value.effect
+    }
+  }
 
   scaling_config {
     max_size     = lookup(each.value, "max_size", 3)


### PR DESCRIPTION
This pull request adds labels and taints for managed node groups. I wanted to transfer this to nodegroups as well but there does not seem to be an obvious way to do it. I looked at https://github.com/terraform-aws-modules/terraform-aws-eks but they also just support labels and taints for managed node groups. One idea to transfer this would be to add an additional user_data script which just adds the label after the node joined the cluster.