### PR TITLE
Add encryption to launch template ebs block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,6 +181,8 @@ resource "aws_launch_template" "ng" {
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
+      kms_key_id            = lookup(each.value, "kms_key_id", null)
+      encrypted             = lookup(each.value, "encrypted", null)
       volume_size           = lookup(each.value, "disk_size", "20")
       volume_type           = "gp2"
       delete_on_termination = true
@@ -316,6 +318,8 @@ resource "aws_launch_template" "mng" {
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
+      kms_key_id            = lookup(each.value, "kms_key_id", null)
+      encrypted             = lookup(each.value, "encrypted", null)
       volume_size           = lookup(each.value, "disk_size", "20")
       volume_type           = "gp2"
       delete_on_termination = true


### PR DESCRIPTION
Another one: I would like to utilize encrypted volumes. Not sure whether we should introduce an explicit block_settings and ebs key in the node groups to mirror the corresponding AWS module. I just started out with terraform on monday and it would've been easier for me if this was unified for this module and the AWS provided modules. I had to check out the module code whenever there was no example to understand how to structure my input which defies the purpose of a module.