### PR TITLE
Support providing VPCID for Fargate hosting

### DIFF
--- a/modules/lb-controller/main.tf
+++ b/modules/lb-controller/main.tf
@@ -39,6 +39,7 @@ resource "helm_release" "lbc" {
       "clusterName"                                               = var.cluster_name
       "serviceAccount.name"                                       = local.serviceaccount
       "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.irsa[0].arn[0]
+      "vpcId"                                                     = var.vpc_id
     }
     content {
       name  = set.key

--- a/modules/lb-controller/variables.tf
+++ b/modules/lb-controller/variables.tf
@@ -36,6 +36,13 @@ variable "petname" {
   default     = true
 }
 
+# for fargate
+variable "vpc_id" {
+  description = "The vpc id to deploy your EKS Cluster"
+  type        = string
+  default     = null
+}
+
 ### tags
 variable "tags" {
   description = "The key-value maps for tagging"


### PR DESCRIPTION
While installing aws lb controller on Fargate, it fails with the below error: 
"error":"failed to introspect vpcID from EC2Metadata, specify --aws-vpc-id instead if EC2Metadata is unavailable: