### PR TITLE
Avoid hardcoded thumbprint_list in aws_iam_openid_connect_provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -416,10 +416,14 @@ resource "aws_eks_fargate_profile" "fargate" {
   ]
 }
 
+data "tls_certificate" "cert" {
+  url = aws_eks_cluster.cp.identity.0.oidc.0.issuer
+}
+
 resource "aws_iam_openid_connect_provider" "oidc" {
   client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
-  url             = aws_eks_cluster.cp.identity.0.oidc.0.issuer
+  thumbprint_list = data.tls_certificate.cert.certificates[*].sha1_fingerprint
+  url             = data.tls_certificate.cert.url
 }
 
 locals {


### PR DESCRIPTION
With https://github.com/hashicorp/terraform-provider-tls/pull/62 we can now read the fingerprints from the server certificate chain dynamically, so there's no longer a need to hardcode `thumbprint_list` in the `aws_iam_openid_connect_provider` resource. This should make the code more compatible and robust, see also [Enabling IAM Roles for Service Accounts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#enabling-iam-roles-for-service-accounts) in the official terraform documentation. Thanks for your project, it is a great source of inspiration for setting up EKS with Terraform.